### PR TITLE
remove conditional delete of map linestrings

### DIFF
--- a/src/components/road-closure-map/index.tsx
+++ b/src/components/road-closure-map/index.tsx
@@ -91,18 +91,15 @@ class RoadClosureMap extends React.Component<IRoadClosureMapProps, IRoadClosureM
   public componentDidUpdate(prevProps: IRoadClosureMapProps) {
     const {
       currentItem,
-      isFetchingMatchedStreets,
     } = this.props.roadClosure;
 
-    if (prevProps.roadClosure.isFetchingMatchedStreets && !isFetchingMatchedStreets) {
-      this.mapDraw.deleteAll();
-      forEach(currentItem.matchedStreets.features, (matchedStreetFeature, index) => {
-        // only render SharedStreetsMatchPaths for now, remove to enable intersections
-        if (matchedStreetFeature instanceof SharedStreetsMatchPath) {
-          this.mapDraw.add(matchedStreetFeature);
-        }
-      });
-    }
+    this.mapDraw.deleteAll();
+    forEach(currentItem.matchedStreets.features, (matchedStreetFeature, index) => {
+      // only render SharedStreetsMatchPaths for now, remove to enable intersections
+      if (matchedStreetFeature instanceof SharedStreetsMatchPath) {
+        this.mapDraw.add(matchedStreetFeature);
+      }
+    });
     
   }
 


### PR DESCRIPTION
always delete and redraw linestrings on props change. might want to change later for performance, but for now this is fine