### PR TITLE
remove erroneous color property from output

### DIFF
--- a/src/selectors/road-closure-geojson.ts
+++ b/src/selectors/road-closure-geojson.ts
@@ -18,7 +18,7 @@ export const currentItemToGeojson = (state: IRoadClosureState) => {
                 })
                 .map((path: SharedStreetsMatchGeomPath) => {
                     path.properties.streetname = state.currentItem.properties.street[path.properties.geometryId][path.properties.direction].streetname;
-                    return omit(path, ['color']);
+                    return omit(path, ['properties.color']);
                 }),
         properties: omit(state.currentItem.properties, ['geometryIdDirectionFilter', 'street'])
     }


### PR DESCRIPTION
an empty `color` property was showing up in the output. this resolves that 