### PR TITLE
updated scheduler design

### DIFF
--- a/src/components/road-closure-form-schedule-block-table-cell/index.tsx
+++ b/src/components/road-closure-form-schedule-block-table-cell/index.tsx
@@ -1,0 +1,69 @@
+import {
+  // AnchorButton,
+  // Popover,
+  Tag,
+} from '@blueprintjs/core';
+import {
+  parseInt
+} from 'lodash';
+import * as moment from 'moment'; 
+import * as React from 'react'; 
+import { IRoadClosureScheduleBlock } from 'src/models/RoadClosureFormStateItem';
+import './road-closure-form-schedule-block-table-cell.css'
+
+export interface IRoadClosureFormScheduleBlockTableCellProps {
+  weekNumber: number,
+  day: string,
+  scheduleBlocks: IRoadClosureScheduleBlock[]
+  onRemove: (e: any, tagProps: any) => void,
+}
+
+export interface IRoadClosureFormScheduleBlockTableCellState {
+  isPopoverOpen: boolean,
+}
+
+class RoadClosureFormScheduleBlockTableCell extends React.Component<IRoadClosureFormScheduleBlockTableCellProps, IRoadClosureFormScheduleBlockTableCellState> {
+  public constructor(props: IRoadClosureFormScheduleBlockTableCellProps) {
+    super(props);
+    this.state = {
+      isPopoverOpen: false
+    };
+  }
+
+  public toggleIsPopoverOpen = () => {
+    this.setState({
+      isPopoverOpen: !this.state.isPopoverOpen
+    })
+  }
+
+  public renderScheduleBlockTag = (scheduleBlock: IRoadClosureScheduleBlock, index: number) => {
+    const startHour = parseInt(scheduleBlock.startTime.split(":")[0], 10);
+    const startMinute = parseInt(scheduleBlock.startTime.split(":")[1], 10);
+    const endHour = parseInt(scheduleBlock.endTime.split(":")[0], 10);
+    const endMinute = parseInt(scheduleBlock.endTime.split(":")[1], 10);
+    const startTimeAsMoment = moment().hour(startHour).minute(startMinute);
+    const endTimeAsMoment = moment().hour(endHour).minute(endMinute);
+
+    let startTimeFormat = startTimeAsMoment.minute() === 0 ? 'h' : 'h:mm';
+    const endTimeFormat = endTimeAsMoment.minute() === 0 ? 'hA' : 'h:mmA';
+    startTimeFormat += startTimeAsMoment.format('a') !== endTimeAsMoment.format('a') ? 'A' : '';
+              
+    return <Tag fill={true} key={index} id={`${this.props.weekNumber}-${this.props.day}-${index}`} onRemove={this.props.onRemove}>
+        {startTimeAsMoment.format(startTimeFormat)}-{endTimeAsMoment.format(endTimeFormat)}
+    </Tag>;
+  }
+
+  public render() {
+    return <div className={"SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Content"}>
+      {
+        this.props.scheduleBlocks.map((scheduleBlock: IRoadClosureScheduleBlock, index: any) => {
+          return <div className={"SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Content-Row"} key={index}>
+            {this.renderScheduleBlockTag(scheduleBlock, index)}
+          </div>
+        })
+      }
+    </div>
+  }
+}
+
+export default RoadClosureFormScheduleBlockTableCell;

--- a/src/components/road-closure-form-schedule-block-table-cell/road-closure-form-schedule-block-table-cell.css
+++ b/src/components/road-closure-form-schedule-block-table-cell/road-closure-form-schedule-block-table-cell.css
@@ -1,0 +1,4 @@
+.SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Content-Row {
+    width: 100%;
+    margin-top: 5px;
+}

--- a/src/components/road-closure-form-schedule-transposed-table/index.tsx
+++ b/src/components/road-closure-form-schedule-transposed-table/index.tsx
@@ -18,7 +18,6 @@ export interface IRoadClosureFormScheduleTransposedTableProps {
     lastWeek: number,
     scheduleByWeek: IRoadClosureScheduleByWeek,
     currentDateRange: DateRange,
-    expandedCalendar: boolean,
     inputRemoved: (e: any) => void,
 };
 

--- a/src/components/road-closure-form-schedule-transposed-table/index.tsx
+++ b/src/components/road-closure-form-schedule-transposed-table/index.tsx
@@ -8,6 +8,7 @@ import {
     // IRoadClosureSchedule,
     IRoadClosureScheduleByWeek,
 } from 'src/models/RoadClosureFormStateItem';
+import RoadClosureFormScheduleBlockTableCell from '../road-closure-form-schedule-block-table-cell';
 import './road-closure-form-schedule-transposed-table.css';
 
 export interface IRoadClosureFormScheduleTransposedTableProps {
@@ -44,54 +45,35 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
         const output: any[] = [];
 
         for (let weekNumber=this.props.firstWeek; weekNumber<=this.props.lastWeek; weekNumber++) {
-            const firstDayOfWeek = moment().week(weekNumber).day(0);
-            // if (firstDayOfWeek.isBefore(this.props.currentDateRange[0])) {
-            //     firstDayOfWeek = moment(this.props.currentDateRange[0]);
-            // }
-            const cols = [];
-            cols.push(
-                <td style={{textAlign: "center", verticalAlign: "middle"}}>{firstDayOfWeek.format("MM/DD")}</td>
-            );
+            const cols: any[] = [];
 
             ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].forEach((day) => {
                 if (!this.props.scheduleByWeek || !this.props.scheduleByWeek[weekNumber] || !this.props.scheduleByWeek[weekNumber][day]) {
                     cols.push(
-                        // TODO - make this display the possible entries
-                        <td style={{width: '100px', padding: '0px', textAlign: "center", verticalAlign: "middle"}}>{''}</td>
+                        <td style={{width: '115px', maxWidth: '115px', height: '10px', padding: '0px', ...headerStyle}}>
+                            <div className={"SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Header"}>
+                                {moment().week(weekNumber).day(day).format("MMM DD")}
+                            </div>
+                        </td>
                     )
                 } else {
-                    if (this.props.expandedCalendar) {
-                        const scheduleBlocks: any[] = []
-                        this.props.scheduleByWeek[weekNumber][day].forEach((scheduleBlock, index) => {
-                            const startHour = parseInt(scheduleBlock.startTime.split(":")[0], 10);
-                            const startMinute = parseInt(scheduleBlock.startTime.split(":")[1], 10);
-                            const endHour = parseInt(scheduleBlock.endTime.split(":")[0], 10);
-                            const endMinute = parseInt(scheduleBlock.endTime.split(":")[1], 10);
-                            const startTimeAsMoment = moment().hour(startHour).minute(startMinute);
-                            const endTimeAsMoment = moment().hour(endHour).minute(endMinute);
-
-                            let startTimeFormat = startTimeAsMoment.minute() === 0 ? 'h' : 'h:mm';
-                            const endTimeFormat = endTimeAsMoment.minute() === 0 ? 'hA' : 'h:mmA';
-                            startTimeFormat += startTimeAsMoment.format('a') !== endTimeAsMoment.format('a') ? 'A' : '';
-
-                            scheduleBlocks.push(
-                                <Tag id={`${weekNumber}-${day}-${index}`} onRemove={this.handleRemoveScheduleBlock}>
-                                    {startTimeAsMoment.format(startTimeFormat)}-{endTimeAsMoment.format(endTimeFormat)}
-                                </Tag>
-                            );
-                        }, this);
-                        cols.push(
-                            <td style={{width: '100px', padding: '0px', textAlign: "center", verticalAlign: "middle"}}>
-                                {scheduleBlocks}
-                            </td>
-                        )
-                    } else {
-                        cols.push(
-                            <td style={{width: '100px', padding: '0px', textAlign: "center", verticalAlign: "middle"}}>
-                                <Tag>{this.props.scheduleByWeek[weekNumber][day].length} ⛔️</Tag>
-                            </td>
-                        );
-                    }
+                    const scheduleBlocks: any[] = []
+                    scheduleBlocks.push(
+                        <RoadClosureFormScheduleBlockTableCell
+                            scheduleBlocks={this.props.scheduleByWeek[weekNumber][day]}
+                            weekNumber={weekNumber}
+                            day={day}
+                            onRemove={this.handleRemoveScheduleBlock}
+                        />
+                    )
+                    cols.push(
+                        <td style={{width: '115px', maxWidth: '115px', height: '60px', padding: '0px'}}>
+                            <div className={"SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Header"}>
+                                {moment().week(weekNumber).day(day).format("MMM DD")}
+                            </div>
+                            {scheduleBlocks}
+                        </td>
+                    )
                 }
             }, this);
             output.push(<tr>{cols}</tr>);

--- a/src/components/road-closure-form-schedule-transposed-table/index.tsx
+++ b/src/components/road-closure-form-schedule-transposed-table/index.tsx
@@ -49,6 +49,15 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
 
             ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"].forEach((day) => {
                 if (!this.props.scheduleByWeek || !this.props.scheduleByWeek[weekNumber] || !this.props.scheduleByWeek[weekNumber][day]) {
+                    let headerStyle = {};
+                    if (
+                        moment().week(weekNumber).day(day).hour(23).minute(59).second(59).isBefore(moment(this.props.currentDateRange[0])) ||
+                        moment().week(weekNumber).day(day).hour(0).minute(0).second(0).isAfter(moment(this.props.currentDateRange[1]))
+                    ) {
+                        headerStyle = {
+                            color: '#CED9E0'
+                        }
+                    }
                     cols.push(
                         <td style={{width: '115px', maxWidth: '115px', height: '10px', padding: '0px', ...headerStyle}}>
                             <div className={"SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Header"}>

--- a/src/components/road-closure-form-schedule-transposed-table/index.tsx
+++ b/src/components/road-closure-form-schedule-transposed-table/index.tsx
@@ -1,16 +1,7 @@
 import {
-    Colors, Tag,
-    // Tag,
+    Colors,
 } from '@blueprintjs/core';
 import { DateRange } from '@blueprintjs/datetime';
-import {
-    // forEach,
-    // head,
-    // isEmpty,
-    // last,
-    // uniq,
-    parseInt,
-} from 'lodash';
 import * as moment from 'moment';
 import * as React from 'react';
 import {
@@ -34,22 +25,18 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
     public constructor(props: IRoadClosureFormScheduleTransposedTableProps) {
         super(props);
         this.handleRemoveScheduleBlock = this.handleRemoveScheduleBlock.bind(this);
-        // this.renderHeader = this.renderHeader.bind(this);
         this.renderRow = this.renderRow.bind(this);
     }
 
     public handleRemoveScheduleBlock(e: any, tagProps: any) {
-        // if (e.target.parentElement.parentElement.previousElementSibling.textContent) {
         const weekFromTag = tagProps.id.split("-")[0];
         const dayFromTag = tagProps.id.split("-")[1];
         const scheduleBlockIndex = tagProps.id.split("-")[2];
         this.props.inputRemoved({
             day: dayFromTag,
-            // endTime: scheduleBlockParts[1],
             index: scheduleBlockIndex,
             key: 'schedule',
             weekOfYear: weekFromTag,
-            // startTime: scheduleBlockParts[0]
         });
     }
 
@@ -112,30 +99,14 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
         return output;
     }
 
-    // public renderRow(day: string) {
-    //     const output: any[] = [];
-    //     for (let weekNumber=this.props.firstWeek; weekNumber<=this.props.lastWeek; weekNumber++) {
-    //         // const firstDayOfWeek = moment().week(weekNumber).day(0);
-    //         // if (firstDayOfWeek.isBefore(this.props.currentDateRange[0])) {
-    //         //     firstDayOfWeek = moment(this.props.currentDateRange[0]);
-    //         // }
-    //     }
-    //     return output;
-    // }
-
     public render() {
         let tableStyle = {};
         if (this.props.week === this.props.currentWeek.toString()) {
             tableStyle = {backgroundColor: Colors.LIGHT_GRAY5}
         }
-        // let headerStyle = {};
-        // if () {
-        //     headerStyle = {};
-        // }
-        return <table className={"SHST-Road-Closure-Form-Scheduler-Table bp3-html-table bp3-small bp3-interactive"} style={tableStyle}>
             <thead>
                 <tr>
-                    <th>{'Week of:'}</th>
+                    {/* <th>{'Week of:'}</th> */}
                     <th style={{width: '100px', padding: '0px', textAlign: 'center', verticalAlign: 'middle'}}>Su</th>
                     <th style={{width: '100px', padding: '0px', textAlign: 'center', verticalAlign: 'middle'}}>M</th>
                     <th style={{width: '100px', padding: '0px', textAlign: 'center', verticalAlign: 'middle'}}>Tu</th>
@@ -143,7 +114,6 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
                     <th style={{width: '100px', padding: '0px', textAlign: 'center', verticalAlign: 'middle'}}>Th</th>
                     <th style={{width: '100px', padding: '0px', textAlign: 'center', verticalAlign: 'middle'}}>F</th>
                     <th style={{width: '100px', padding: '0px', textAlign: 'center', verticalAlign: 'middle'}}>Sa</th>
-                    {/* {this.renderHeader()} */}
                 </tr>
             </thead>
             <tbody>

--- a/src/components/road-closure-form-schedule-transposed-table/index.tsx
+++ b/src/components/road-closure-form-schedule-transposed-table/index.tsx
@@ -86,6 +86,8 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
         if (this.props.week === this.props.currentWeek.toString()) {
             tableStyle = {backgroundColor: Colors.LIGHT_GRAY5}
         }
+
+        return <table className={"SHST-Road-Closure-Form-Scheduler-Table bp3-html-table bp3-small bp3-interactive bp3-html-table-striped"} style={tableStyle}>
             <thead>
                 <tr>
                     {/* <th>{'Week of:'}</th> */}

--- a/src/components/road-closure-form-schedule-transposed-table/road-closure-form-schedule-transposed-table.css
+++ b/src/components/road-closure-form-schedule-transposed-table/road-closure-form-schedule-transposed-table.css
@@ -1,3 +1,9 @@
 .SHST-Road-Closure-Form-Scheduler-Table {
     width: 100%;
 }
+.SHST-Road-Closure-Form-Schedule-Block-Table-Cell-Header {
+    width: 100%;
+    text-align: center;
+    font-size: 12px;
+    font-weight: bold;
+}

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  ButtonGroup,
   Card,
   Checkbox,
   Collapse,
@@ -24,14 +23,11 @@ import {
 } from 'lodash';
 import * as moment from 'moment';
 import * as React from 'react';
-import WeekCalendar from 'react-week-calendar';
 import RoadClosureOutputViewer from 'src/containers/road-closure-output-viewer';
 import { IRoadClosureMode } from 'src/models/RoadClosureFormStateItem';
 import { SharedStreetsMatchGeomFeatureCollection } from 'src/models/SharedStreets/SharedStreetsMatchGeomFeatureCollection';
 import { IRoadClosureState } from 'src/store/road-closure';
 import RoadClosureFormScheduleEntry from '../road-closure-form-schedule-entry';
-import RoadClosureFormScheduleEvent from '../road-closure-form-schedule-event';
-import RoadClosureFormScheduleHeaderCell from '../road-closure-form-schedule-header-cell';
 import RoadClosureFormScheduleTransposedTable from '../road-closure-form-schedule-transposed-table';
 import RoadClosureFormStreetsGroups from '../road-closure-form-streets-groups';
 
@@ -385,10 +381,6 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                     inputChanged={this.props.inputChanged}
                     currentDateRange={currentDateRange}
                     schedule={this.props.currentRoadClosureItem.properties.schedule} />
-                  <Checkbox
-                    onChange={this.handleToggleCalendarExpanded}
-                    checked={this.state.isCalendarExpanded}
-                    label={"View expanded calendar"} />
                 </div>
                 <div className={"SHST-Road-Closure-Form-Schedule-Tables"}>
                 <RoadClosureFormScheduleTransposedTable
@@ -400,35 +392,9 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                   firstWeek={moment(currentDateRange[0]).week()}
                   lastWeek={moment(currentDateRange[1]).week()}
                   scheduleByWeek={this.props.currentRoadClosureItem.properties.schedule}
-                  expandedCalendar={this.state.isCalendarExpanded}
+                  expandedCalendar={true}
                   />
                 </div>
-                {
-                  this.state.isCalendarExpanded &&
-                  <React.Fragment>
-                    <ButtonGroup>
-                      <Button
-                        onClick={this.handleClickPreviousWeek}
-                        disabled={this.state.weekOfYear === moment(currentDateRange[0]).week()}
-                        text={"Previous week"} />
-                      <Button
-                        onClick={this.handleClickNextWeek}
-                        disabled={this.state.weekOfYear === moment(currentDateRange[1]).week()}
-                        text={"Next week"} />
-                    </ButtonGroup>
-                    <WeekCalendar
-                      scaleHeaderTitle={`${this.state.firstDayOfWeek.format("MMM/DD")}-${this.state.firstDayOfWeek.clone().add(1, "week").format("MMM/DD")}`}
-                      className={"SHST-Road-Closure-Form-Schedule-Calendar"}
-                      scaleUnit={60}
-                      cellHeight={15}
-                      useModal={false}
-                      firstDay={this.state.firstDayOfWeek}
-                      headerCellComponent={RoadClosureFormScheduleHeaderCell}
-                      eventComponent={RoadClosureFormScheduleEvent}
-                      selectedIntervals={this.props.selectedIntervals}
-                    />
-                  </React.Fragment>
-                }
               </Collapse>
             </FormGroup>
             <FormGroup

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -393,7 +393,6 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                   firstWeek={moment(currentDateRange[0]).week()}
                   lastWeek={moment(currentDateRange[1]).week()}
                   scheduleByWeek={this.props.currentRoadClosureItem.properties.schedule}
-                  expandedCalendar={true}
                   />
                 </div>
               </Collapse>

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -375,6 +375,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               <Collapse isOpen={this.state.isShowingScheduler}>
                 <div style={{display: 'flex', flexDirection: 'row', justifyContent: 'space-between'}}>
                   <RoadClosureFormScheduleEntry
+                    key={currentDateRange.toString()}
                     firstWeek={moment(currentDateRange[0]).week()}
                     lastWeek={moment(currentDateRange[1]).week()}
                     weekOfYear={this.state.weekOfYear}

--- a/src/store/road-closure/index.ts
+++ b/src/store/road-closure/index.ts
@@ -830,10 +830,10 @@ export const roadClosureReducer = (state: IRoadClosureState = defaultState, acti
                     });
                 }
             } else {
-                if (key === "startTime" || key === "endTime") {
+                if (key === "startTime" || key === "endTime" && !isEmpty(state.currentItem.properties.schedule)) {
                     const payloadAsMoment = moment(action.payload[key]);
                     const stateTimeAsMoment = moment(state.currentItem.properties[key]);
-                    if (payloadAsMoment.isAfter(stateTimeAsMoment)) {
+                    if (key === "startTime" && payloadAsMoment.isAfter(stateTimeAsMoment)) {
                         // when start of range pushed back
                         // remove schedule items that fall outside the range
                         if (payloadAsMoment.week() > stateTimeAsMoment.week()) {
@@ -856,12 +856,12 @@ export const roadClosureReducer = (state: IRoadClosureState = defaultState, acti
                         // remove schedule items that fall outside the range
                         if (payloadAsMoment.week() < stateTimeAsMoment.week()) {
                             const weeksToOmit = [];
-                            for (let i = payloadAsMoment.week(); i<stateTimeAsMoment.week(); i++) {
+                            for (let i = payloadAsMoment.week()+1; i<=stateTimeAsMoment.week(); i++) {
                                 weeksToOmit.push(i);
                             }
                             updatedItem.properties.schedule = omit(updatedItem.properties.schedule, weeksToOmit);
                         }
-                        for (let i = payloadAsMoment.day(); i<7; i++) {
+                        for (let i = payloadAsMoment.day()+1; i<7; i++) {
                             // drop all days after day of new endTime
                             updatedItem.properties.schedule[payloadAsMoment.week()] = omit(updatedItem.properties.schedule[payloadAsMoment.week()], moment().day(i).format("dddd"));
                         }

--- a/src/store/road-closure/index.ts
+++ b/src/store/road-closure/index.ts
@@ -877,45 +877,6 @@ export const roadClosureReducer = (state: IRoadClosureState = defaultState, acti
                 ...state,
                 currentItem: updatedItem,
             }
-        // case "ROAD_CLOSURE/INPUT_CHANGED":
-        //     const inputChangedKey = action.payload.key;
-        //     updatedItem = Object.assign(Object.create(state.currentItem), state.currentItem);
-
-        //     if (inputChangedKey === "street") {
-        //         forEach(Object.keys(updatedItem.properties[inputChangedKey][action.payload.geometryId]), (refId: string) => {
-        //             updatedItem.properties[inputChangedKey][action.payload.geometryId][refId].streetname = action.payload.street;
-        //         });
-        //     } else if (inputChangedKey === "mode") {
-        //         if (!updatedItem.properties[inputChangedKey]) {
-        //             updatedItem.properties[inputChangedKey] = [];
-        //         }
-        //         if (updatedItem.properties[inputChangedKey] && updatedItem.properties[inputChangedKey].includes(action.payload[inputChangedKey])) {
-        //             const removeIndex = updatedItem.properties[inputChangedKey].indexOf(action.payload[inputChangedKey]);
-        //             updatedItem.properties[inputChangedKey].splice(removeIndex, 1);
-        //         } else {
-        //             updatedItem.properties[inputChangedKey].push(action.payload[inputChangedKey]);
-        //         }
-        //     } else if (inputChangedKey === "schedule") {
-        //         if (!updatedItem.properties[inputChangedKey][action.payload.weekOfYear!][action.payload.day!]) {
-        //             updatedItem.properties[inputChangedKey][action.payload.weekOfYear!][action.payload.day!] = [];
-        //         }
-        //         if (!isEmpty(action.payload.startTime) && action.payload.startTime &&
-        //             !isEmpty(action.payload.endTime) && action.payload.endTime && 
-        //             action.payload.startTime !== action.payload.endTime
-        //         ) {
-        //             updatedItem.properties[inputChangedKey][action.payload.weekOfYear!][action.payload.day!].push({
-        //                 endTime: action.payload.endTime,
-        //                 startTime: action.payload.startTime,
-        //             });
-        //         }
-        //     } else {
-        //         updatedItem.properties[inputChangedKey] = action.payload[inputChangedKey];
-        //     }
-            
-        //     return {
-        //         ...state,
-        //         currentItem: updatedItem,
-        //     }
 
             case "ROAD_CLOSURE/INPUT_REMOVED":
                 const removedInputKey = action.payload.key;


### PR DESCRIPTION
also for #78 
![image](https://user-images.githubusercontent.com/444765/62168515-bf6e8880-b2f3-11e9-9026-8134eebde7c6.png)
- settled on full calendar view
- added all dates into the calendar view
- 10px height when no scheduled events exist 
- dates outside of overall date-time range greyed out 
![image](https://user-images.githubusercontent.com/444765/62168606-efb62700-b2f3-11e9-9c1e-3c907ed7c2f6.png)
- if scheduled closures exist, show them all
- date justified top
- times justified left