### PR TITLE
reset upload URLs from redux store on navigation

### DIFF
--- a/src/store/road-closure/index.ts
+++ b/src/store/road-closure/index.ts
@@ -908,14 +908,7 @@ export const roadClosureReducer = (state: IRoadClosureState = defaultState, acti
             };
 
         case "ROAD_CLOSURE/RESET_ROAD_CLOSURE":
-            return {
-                ...state,
-                allOrgs: [],
-                currentItem: new SharedStreetsMatchGeomFeatureCollection(),
-                isEditingExistingClosure: false,
-                isLoadedInput: false,
-                isLoadingAllRoadClosures: false,
-            };
+            return defaultState;
             
         default:
             return state;

--- a/src/store/road-closure/road-closure.spec.tsx
+++ b/src/store/road-closure/road-closure.spec.tsx
@@ -467,6 +467,29 @@ test('ACTION: ROAD_CLOSURE/INPUT_CHANGED - date with existing date & schedule - 
     expect(roadClosureReducer(startingState, ROAD_CLOSURE_ACTIONS.INPUT_CHANGED(payload))).toEqual(expectedState)
 });
 
+test('ACTION: ROAD_CLOSURE/RESET_ROAD_CLOSURE', () => {
+    const startingState = Object.assign({}, defaultState);
+
+    currentItem = new SharedStreetsMatchGeomFeatureCollection();
+    currentItem.properties.description = "updated description";
+    currentItem.properties.reference = "REF";
+    currentItem.properties.startTime = "20";
+    currentItem.properties.subtype = "ROAD_CLOSED_CONSTRUCTION";
+    startingState.currentItem = currentItem;
+
+    startingState.uploadUrls = {
+        geojsonUploadUrl: 'https://geojson.com',
+        wazeUploadUrl: 'https://waze.com',
+    }
+
+    startingState.allOrgs = [
+        {}, {}, {}
+    ];
+
+    const expectedState = Object.assign({}, defaultState);
+
+    expect(roadClosureReducer(startingState, ROAD_CLOSURE_ACTIONS.RESET_ROAD_CLOSURE())).toEqual(expectedState)
+});
 
 // test('ACTION: ROAD_CLOSURE/INPUT_CHANGED - form', () => {
 //     const startingState = Object.assign({}, defaultState);


### PR DESCRIPTION
the redux store contains upload URLs to present, and to use to save a new or update an existing closure. when navigating within the app (specifically when `src/App.tsx` is mounted in the case where there needs to be a new closure created https://github.com/sharedstreets/sharedstreets-road-closure-ui/blob/master/src/App.tsx#L60), the state was not getting reset appropriately, causing a just-used URL to be reused. 

this change returns the default state in the `ROAD_CLOSURE/RESET_ROAD_CLOSURE` action