### PR TITLE
when drawing, show possible directions on hover

### DIFF
--- a/src/components/road-closure-map/index.tsx
+++ b/src/components/road-closure-map/index.tsx
@@ -104,6 +104,7 @@ class RoadClosureMap extends React.Component<IRoadClosureMapProps, IRoadClosureM
       this.mapContainer.getCanvas().style.cursor = this.state.isDrawing ? 'crosshair' : '';
     })
     this.mapContainer.on('click', this.handleMapClick);
+    this.mapContainer.on('mousemove', this.handleShowPossibleDirections)
     this.mapContainer.addControl(
       new mapboxgl.NavigationControl()
     );
@@ -359,12 +360,18 @@ class RoadClosureMap extends React.Component<IRoadClosureMapProps, IRoadClosureM
     });
   }
 
-  public handleMapClick = (event: any) => {
+  public handleShowPossibleDirections = (event: any) => {
     if (this.state.isDrawing) {
       this.props.findMatchedPoint(
         point([event.lngLat.lng, event.lngLat.lat]),
         this.state.currentLineId,
       );
+    }
+  }
+
+  public handleMapClick = (event: any) => {
+    if (this.state.isDrawing) {
+
 
       const newSelectedCoordinates = Object.assign({}, this.state.selectedCoordinates);
       if (newSelectedCoordinates[this.state.currentLineId].length === 0) {


### PR DESCRIPTION
show the possible directional arrows while hovering, instead of after clicking.

![show-directions-on-hover](https://user-images.githubusercontent.com/444765/63448598-3fc46d00-c40c-11e9-9b3b-73bc9961a851.gif)
