### PR TITLE
add read-only view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,8 @@ export interface IAppProps {
   hideMessage: (d: boolean) => void,
   loadRoadClosure: (url: string) => void,
   resetRoadClosure: () => void,
-  setOrgName: (name: string) => void
+  setOrgName: (name: string) => void,
+  setReadOnly: () => void,
 };
 
 const AppToaster = Toaster.create({
@@ -51,6 +52,9 @@ class App extends React.Component<IAppProps, any> {
       const queryParams = qs.parse(this.props.location.search, {
         ignoreQueryPrefix: true
       });
+      if (queryParams.readOnly && queryParams.readOnly === "true") {
+        this.props.setReadOnly();
+      }
       if (queryParams.url) {
         this.props.loadRoadClosure(queryParams.url);
       } else {
@@ -107,5 +111,6 @@ export default connect<{}, {}, IAppProps>(
     loadRoadClosure,
     resetRoadClosure: ROAD_CLOSURE_ACTIONS.RESET_ROAD_CLOSURE,
     setOrgName: CONTEXT_ACTIONS.SET_ORG_NAME,
+    setReadOnly: CONTEXT_ACTIONS.SET_READ_ONLY,
   }
 )(App) as React.ComponentClass<{}>;

--- a/src/components/road-closure-form-schedule-block-table-cell/index.tsx
+++ b/src/components/road-closure-form-schedule-block-table-cell/index.tsx
@@ -4,7 +4,8 @@ import {
   Tag,
 } from '@blueprintjs/core';
 import {
-  parseInt
+  noop,
+  parseInt,
 } from 'lodash';
 import * as moment from 'moment'; 
 import * as React from 'react'; 
@@ -14,7 +15,8 @@ import './road-closure-form-schedule-block-table-cell.css'
 export interface IRoadClosureFormScheduleBlockTableCellProps {
   weekNumber: number,
   day: string,
-  scheduleBlocks: IRoadClosureScheduleBlock[]
+  scheduleBlocks: IRoadClosureScheduleBlock[],
+  readOnly: boolean,
   onRemove: (e: any, tagProps: any) => void,
 }
 
@@ -48,7 +50,11 @@ class RoadClosureFormScheduleBlockTableCell extends React.Component<IRoadClosure
     const endTimeFormat = endTimeAsMoment.minute() === 0 ? 'hA' : 'h:mmA';
     startTimeFormat += startTimeAsMoment.format('a') !== endTimeAsMoment.format('a') ? 'A' : '';
               
-    return <Tag fill={true} key={index} id={`${this.props.weekNumber}-${this.props.day}-${index}`} onRemove={this.props.onRemove}>
+    return <Tag
+              fill={true}
+              key={index}
+              id={`${this.props.weekNumber}-${this.props.day}-${index}`}
+              onRemove={this.props.readOnly ? noop : this.props.onRemove}>
         {startTimeAsMoment.format(startTimeFormat)}-{endTimeAsMoment.format(endTimeFormat)}
     </Tag>;
   }

--- a/src/components/road-closure-form-schedule-entry/index.tsx
+++ b/src/components/road-closure-form-schedule-entry/index.tsx
@@ -37,6 +37,7 @@ export interface IRoadClosureFormScheduleEntryProps {
     schedule: IRoadClosureScheduleByWeek
     weekOfYear: number,
     currentDateRange: DateRange,
+    readOnly: boolean,
     inputChanged: (e: any) => void,
 };
 
@@ -238,7 +239,11 @@ class RoadClosureFormScheduleEntry extends React.Component<IRoadClosureFormSched
         const endTimeAsDate = moment().hour(endHour).minute(endMinute).toDate();
 
         return <React.Fragment>
-            <Button intent={'primary'} text={"Add a weekly closure schedule"} onClick={this.handleOpen} />
+            <Button
+                disabled={this.props.readOnly}
+                intent={'primary'}
+                text={"Add a weekly closure schedule"}
+                onClick={this.handleOpen} />
             <Dialog
                 title={"Add a weekly closure schedule"}
                 icon={"calendar"}

--- a/src/components/road-closure-form-schedule-transposed-table/index.tsx
+++ b/src/components/road-closure-form-schedule-transposed-table/index.tsx
@@ -18,6 +18,7 @@ export interface IRoadClosureFormScheduleTransposedTableProps {
     lastWeek: number,
     scheduleByWeek: IRoadClosureScheduleByWeek,
     currentDateRange: DateRange,
+    readOnly: boolean,
     inputRemoved: (e: any) => void,
 };
 
@@ -68,6 +69,7 @@ class RoadClosureFormScheduleTransposedTable extends React.Component<IRoadClosur
                     const scheduleBlocks: any[] = []
                     scheduleBlocks.push(
                         <RoadClosureFormScheduleBlockTableCell
+                            readOnly={this.props.readOnly}
                             scheduleBlocks={this.props.scheduleByWeek[weekNumber][day]}
                             weekNumber={weekNumber}
                             day={day}

--- a/src/components/road-closure-form-streets-groups-item/index.tsx
+++ b/src/components/road-closure-form-streets-groups-item/index.tsx
@@ -30,6 +30,7 @@ export interface IRoadClosureFormStreetsGroupItemProps {
     index: number,
     streets: any,
     geometryIdDirectionFilter: { [ geometryId: string] : { forward: boolean, backward: boolean } },
+    readOnly: boolean,
     deleteStreetSegment: (payload: any) => void,
     inputChanged: (e: any) => void,
     toggleStreetSegmentDirection: (e: any) => void,
@@ -220,6 +221,7 @@ class RoadClosureFormStreetsGroupItem extends React.Component<IRoadClosureFormSt
                         fill={true}
                     >
                         <Button
+                            disabled={this.props.readOnly}
                             title={'Delete this group'}
                             icon={"delete"}
                             intent={"danger"}
@@ -234,6 +236,7 @@ class RoadClosureFormStreetsGroupItem extends React.Component<IRoadClosureFormSt
                             onClick={this.handleClick}
                         />
                         <Button
+                            disabled={this.props.readOnly}
                             title={this.state.isIntersectionsIncluded ? 'Exclude all intersections' : 'Include all intersections'}
                             icon={"intersection"}
                             text={this.state.isIntersectionsIncluded ? 'Exclude all intersections' : 'Include all intersections'}
@@ -261,6 +264,7 @@ class RoadClosureFormStreetsGroupItem extends React.Component<IRoadClosureFormSt
                             matchedStreetsGroupsGeometryIdPathMap={this.props.matchedStreetsGroupsGeometryIdPathMap}
                             geometryIdDirectionFilter={this.props.geometryIdDirectionFilter}
                             highlightMatchedStreet={this.props.highlightMatchedStreet}
+                            readOnly={this.props.readOnly}
                         />
                     </Collapse>
         </Card>

--- a/src/components/road-closure-form-streets-groups/index.tsx
+++ b/src/components/road-closure-form-streets-groups/index.tsx
@@ -14,6 +14,7 @@ export interface IRoadClosureFormStreetsGroupsProps {
     geometryIdDirectionFilter: { [ geometryId: string] : { forward: boolean, backward: boolean } },
     streets: any,
     isFetchingMatchedStreets: boolean,
+    readOnly: boolean,
     deleteStreetSegment: (payload: any) => void,
     highlightMatchedStreet: () => void,
     highlightMatchedStreetsGroup: () => void,
@@ -51,6 +52,7 @@ class RoadClosureFormStreetsGroups extends React.Component<IRoadClosureFormStree
                         highlightMatchedStreet={this.props.highlightMatchedStreet}
                         highlightMatchedStreetsGroup={this.props.highlightMatchedStreetsGroup}
                         zoomHighlightMatchedStreetsGroup={this.props.zoomHighlightMatchedStreetsGroup}
+                        readOnly={this.props.readOnly}
                     />
                 })
             }

--- a/src/components/road-closure-form-streets-table-row/index.tsx
+++ b/src/components/road-closure-form-streets-table-row/index.tsx
@@ -17,7 +17,8 @@ export interface IRoadClosureFormStreetsTableRowProps {
     // matchedStreetsGroup: Array<SharedStreetsMatchPath|SharedStreetsMatchPoint>,
     currentFeature: SharedStreetsMatchGeomPath,
     key: string,
-    street: RoadClosureFormStateStreet
+    street: RoadClosureFormStateStreet,
+    readOnly: boolean,
     deleteStreetSegment: (payload: any) => void,
     inputChanged: (e: any) => void,
     highlightMatchedStreet: (e: any) => void,
@@ -107,6 +108,7 @@ class RoadClosureFormStreetsTableRow extends React.Component<IRoadClosureFormStr
                     key={geometryId}>
                 <td>
                     <Button
+                        disabled={this.props.readOnly}
                         id={geometryId}
                         onClick={this.handleDeleteStreetSegment}
                         icon={"delete"}
@@ -114,6 +116,7 @@ class RoadClosureFormStreetsTableRow extends React.Component<IRoadClosureFormStr
                 </td>
                 <td>
                     <InputGroup
+                        disabled={this.props.readOnly}
                         key={"input-"+geometryId}
                         id={geometryId}
                         // value={streetname}
@@ -122,7 +125,7 @@ class RoadClosureFormStreetsTableRow extends React.Component<IRoadClosureFormStr
                         onChange={this.handleChangeStreetName}
                         rightElement={
                             <Button 
-                                disabled={this.state.streetnameValue === this.props.street.streetname}
+                                disabled={this.state.streetnameValue === this.props.street.streetname || this.props.readOnly}
                                 onClick={this.handleDispatchStreetName}
                                 minimal={true}
                                 icon={"tick"}
@@ -133,7 +136,7 @@ class RoadClosureFormStreetsTableRow extends React.Component<IRoadClosureFormStr
                 </td>
                 <td>
                     <Checkbox
-                        disabled={!intersectionValidity.fromIntersection}
+                        disabled={!intersectionValidity.fromIntersection || this.props.readOnly}
                         onChange={this.handleChangeIntersectionStatusChanged}
                         id={'fromIntersection'}
                         checked={this.props.street.intersectionsStatus && this.props.street.intersectionsStatus[this.props.street.fromIntersectionId]}
@@ -156,7 +159,7 @@ class RoadClosureFormStreetsTableRow extends React.Component<IRoadClosureFormStr
                 </td>
                 <td>
                     <Checkbox
-                        disabled={!intersectionValidity.toIntersection}
+                        disabled={!intersectionValidity.toIntersection || this.props.readOnly}
                         onChange={this.handleChangeIntersectionStatusChanged}
                         id={'toIntersection'}
                         checked={this.props.street.intersectionsStatus && this.props.street.intersectionsStatus[this.props.street.toIntersectionId]}

--- a/src/components/road-closure-form-streets-table/index.tsx
+++ b/src/components/road-closure-form-streets-table/index.tsx
@@ -11,6 +11,7 @@ export interface IRoadClosureFormStreetsTableProps {
     matchedStreetsGroupsGeometryIdPathMap: { [geomId: string]: { [direction: string] : SharedStreetsMatchGeomPath} },
     geometryIdDirectionFilter: { [ geometryId: string] : { forward: boolean, backward: boolean } },
     streets: any,
+    readOnly: boolean,
     deleteStreetSegment: (payload: any) => void,
     highlightMatchedStreet: (e: any) => void,
     inputChanged: (e: any) => void,
@@ -53,6 +54,7 @@ class RoadClosureFormStreetsTable extends React.Component<IRoadClosureFormStreet
                             ) as SharedStreetsMatchGeomPath[];
 
                         return <RoadClosureFormStreetsTableRow
+                            readOnly={this.props.readOnly}
                             highlightMatchedStreet={this.props.highlightMatchedStreet}
                             currentFeature={currentFeature[0]}
                             inputChanged={this.props.inputChanged}

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -50,6 +50,7 @@ export interface IRoadClosureFormProps {
   previousSelection: () => void,
   inputChanged: (payload: any) => void,
   inputRemoved: (payload: any) => void,
+  readOnly: boolean,
   roadClosure: IRoadClosureState,
   currentRoadClosureGroups: any,
   currentRoadClosureGroupsDirection: any,
@@ -322,6 +323,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 streets={this.props.currentRoadClosureItem.properties.street}
                 isFetchingMatchedStreets={this.props.roadClosure.isFetchingMatchedStreets}
                 zoomHighlightMatchedStreetsGroup={this.props.zoomHighlightMatchedStreetsGroup}
+                readOnly={this.props.readOnly}
               />
             }
             <FormGroup
@@ -330,6 +332,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               className={"SHST-Road-Closure-Form-Group-Date-Time"}
             >
               <DateRangeInput
+                disabled={this.props.readOnly}
                 value={currentDateRange}
                 className={"SHST-Road-Closure-Form-Date-Range-Input-Group"}
                 allowSingleDayRange={true}
@@ -348,6 +351,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 }}
               />
               <TimezonePicker
+                disabled={this.props.readOnly}
                 inputProps={{
                   className: "SHST-Timezone-Picker-Input",
                 }}
@@ -403,6 +407,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               labelInfo="(required)"
             >
               <InputGroup
+                  disabled={this.props.readOnly}
                   placeholder={"Enter a description of the closure here..."}
                   onChange={this.handleChangeDescription}
                   value={currentDescription}
@@ -414,6 +419,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               labelInfo="(required)"
             >
               <InputGroup
+                  disabled={this.props.readOnly}                
                   placeholder={"Enter the name of your organization here..."}
                   onChange={this.handleChangeReference}
                   value={this.props.currentRoadClosureItem.properties.reference}
@@ -424,6 +430,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               labelInfo={"(optional)"}>
               <div className="bp3-select">
                 <select
+                  disabled={this.props.readOnly}
                   value={this.props.currentRoadClosureItem.properties.subtype}
                   onChange={this.handleChangeSubtype}>
                   <option defaultChecked={true} value={''}>Choose a subtype...</option>
@@ -439,10 +446,12 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               label="Mode"
               labelInfo="(optional)">
               <Button
+                disabled={this.props.readOnly}
                 text={"Select All"}
                 onClick={this.selectAllModes}
               />
               <Checkbox
+                disabled={this.props.readOnly}
                 checked={
                   this.props.currentRoadClosureItem.properties.mode
                   && this.props.currentRoadClosureItem.properties.mode.includes(IRoadClosureMode.ROAD_CLOSED_PEDESTRIAN)
@@ -452,6 +461,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 value={IRoadClosureMode.ROAD_CLOSED_PEDESTRIAN}
               />
               <Checkbox
+                disabled={this.props.readOnly}
                 checked={
                   this.props.currentRoadClosureItem.properties.mode
                   && this.props.currentRoadClosureItem.properties.mode.includes(IRoadClosureMode.ROAD_CLOSED_BICYCLE)
@@ -461,6 +471,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 value={IRoadClosureMode.ROAD_CLOSED_BICYCLE}
               />
               <Checkbox
+                disabled={this.props.readOnly}
                 defaultChecked={true}
                 checked={
                   this.props.currentRoadClosureItem.properties.mode
@@ -471,6 +482,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 value={IRoadClosureMode.ROAD_CLOSED_BUS}
               />
               <Checkbox
+                disabled={this.props.readOnly}
                 checked={
                   this.props.currentRoadClosureItem.properties.mode
                   && this.props.currentRoadClosureItem.properties.mode.includes(IRoadClosureMode.ROAD_CLOSED_CAR)
@@ -480,6 +492,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 value={IRoadClosureMode.ROAD_CLOSED_CAR}
               />
               <Checkbox
+                disabled={this.props.readOnly}
                 checked={
                   this.props.currentRoadClosureItem.properties.mode
                   && this.props.currentRoadClosureItem.properties.mode.includes(IRoadClosureMode.ROAD_CLOSED_TAXI_RIDESHARE)

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -388,6 +388,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               <Collapse isOpen={this.state.isShowingScheduler}>
                 <div style={{display: 'flex', flexDirection: 'row', justifyContent: 'space-between'}}>
                   <RoadClosureFormScheduleEntry
+                    readOnly={this.props.readOnly}
                     key={currentDateRange.toString()}
                     firstWeek={moment(currentDateRange[0]).week()}
                     lastWeek={moment(currentDateRange[1]).week()}

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -336,7 +336,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               />
             }
             <FormGroup
-              label="Start and end time"
+              label="Start time, end time, and time zone"
               labelInfo="(required)"
               className={"SHST-Road-Closure-Form-Group-Date-Time"}
             >
@@ -353,7 +353,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 contiguousCalendarMonths={false}
                 selectAllOnFocus={true}
                 startInputProps={{
-                  className: "SHST-Road-Closure-Form-Date-Range-Input"
+                  className: "SHST-Road-Closure-Form-Date-Range-Input",
                 }}
                 endInputProps={{
                   className: "SHST-Road-Closure-Form-Date-Range-Input"

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -100,6 +100,14 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
     }
   }
 
+  public componentDidMount() {
+    if (!isEmpty(this.props.currentRoadClosureItem.properties.schedule)) {
+      this.setState({
+        isShowingScheduler: true
+      })
+    }
+  }
+
   public handleDeleteStreetSegment(e: any) {
     this.props.deleteStreetSegment(e.target.parentElement.parentElement.id);
     return;
@@ -372,7 +380,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
               helperText={this.state.isShowingScheduler ? "Closure will only be active within the start and end times AND within the times specified in Schedule" : ''}
               >
               <Switch
-                disabled={!(currentDateRange[0] && currentDateRange[1])}
+                disabled={!(currentDateRange[0] && currentDateRange[1]) || this.props.readOnly}
                 onChange={this.handleToggleShowingScheduler}
                 checked={this.state.isShowingScheduler}
                 label={"Set a specific schedule for this closure within the specified range"} />

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -100,8 +100,9 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
     }
   }
 
-  public componentDidMount() {
-    if (!isEmpty(this.props.currentRoadClosureItem.properties.schedule)) {
+  public componentDidUpdate(prevProps: IRoadClosureFormProps) {
+    if (prevProps.currentRoadClosureItem.properties.schedule !== this.props.currentRoadClosureItem.properties.schedule &&
+      !isEmpty(this.props.currentRoadClosureItem.properties.schedule)) {
       this.setState({
         isShowingScheduler: true
       })

--- a/src/components/road-closure-form/index.tsx
+++ b/src/components/road-closure-form/index.tsx
@@ -399,6 +399,7 @@ class RoadClosureForm extends React.Component<IRoadClosureFormProps, IRoadClosur
                 </div>
                 <div className={"SHST-Road-Closure-Form-Schedule-Tables"}>
                 <RoadClosureFormScheduleTransposedTable
+                  readOnly={this.props.readOnly}
                   key={0}
                   week={'0'}
                   currentWeek={this.state.weekOfYear}

--- a/src/components/road-closure-form/road-closure-form.css
+++ b/src/components/road-closure-form/road-closure-form.css
@@ -20,12 +20,17 @@
     width: 100%;
 }
 
+.SHST-Road-Closure-Form-Date-Range-Input-Group .bp3-control-group {
+    flex-direction: column;
+}
+
 .SHST-Road-Closure-Form-Date-Range-Input {
     flex: 1 1;
 }
 
 .SHST-Road-Closure-Form-Group-Date-Time > div {
     display: flex;
+    flex-direction: column;
 }
 
 .SHST-Road-Closure-Form-Date-Range-Input-Group {

--- a/src/components/road-closure-header-menu/index.tsx
+++ b/src/components/road-closure-header-menu/index.tsx
@@ -21,6 +21,7 @@ export interface IRoadClosureHeaderMenuProps {
     geojsonUploadUrl: string,
     edit?: boolean,
     explore?: boolean,
+    readOnly: boolean,
     addFile: (e: File) => void,
     clearRoadClosure: () => void,
     loadRoadClosure: (url: string) => void,
@@ -115,7 +116,7 @@ class RoadClosureHeaderMenu extends React.Component<IRoadClosureHeaderMenuProps,
     public render() {
         return (
             <React.Fragment>
-                {this.props.edit && this.props.isEditingExistingClosure &&
+                { !this.props.readOnly &&this.props.edit && this.props.isEditingExistingClosure &&
                     <Tag
                         large={true}
                         intent={"danger"}
@@ -123,9 +124,17 @@ class RoadClosureHeaderMenu extends React.Component<IRoadClosureHeaderMenuProps,
                             You are editing a published closure
                     </Tag>
                 }
+                { this.props.readOnly && this.props.edit && 
+                    <Tag
+                        large={true}
+                        intent={"warning"}
+                        title={"Read only"}>
+                            You are in viewing this in read-only mode
+                    </Tag>
+                }
                 { this.props.explore && <Link className={"bp3-button bp3-intent-success"} to="edit">Create new closure</Link> }
-                { this.props.edit && !process.env.REACT_APP_EDIT_ONLY && <Link className={"bp3-button bp3-intent-primary"} to="explore">View all road closures</Link> }
-                { this.props.edit &&
+                { !this.props.readOnly && this.props.edit && !process.env.REACT_APP_EDIT_ONLY && <Link className={"bp3-button bp3-intent-primary"} to="explore">View all road closures</Link> }
+                { !this.props.readOnly && this.props.edit &&
                     <label className="bp3-file-input">
                         <input
                             ref={this.fileInputRef}

--- a/src/components/road-closure-output-viewer/index.tsx
+++ b/src/components/road-closure-output-viewer/index.tsx
@@ -34,6 +34,7 @@ export interface IRoadClosureOutputViewerProps {
     isSavingOutput: boolean,
     isOutputItemEmpty: boolean,
     outputItemFormattedJSONString: string,
+    readOnly: boolean,
     uploadUrls: IRoadClosureUploadUrls,
   };
 
@@ -114,7 +115,7 @@ class RoadClosureOutputViewer extends React.Component<IRoadClosureOutputViewerPr
                         { !process.env.REACT_APP_EDIT_ONLY &&
                         <Button
                             title={"You have to create a road closure before you can save & publish it"}
-                            disabled={this.props.isOutputItemEmpty}
+                            disabled={this.props.isOutputItemEmpty || this.props.readOnly}
                             large={true}
                             intent={"primary"}
                             text={this.props.isEditingExistingClosure ? "Save closure & Publish" : "Save closure & Publish"}

--- a/src/components/road-closure-output-viewer/index.tsx
+++ b/src/components/road-closure-output-viewer/index.tsx
@@ -112,10 +112,10 @@ class RoadClosureOutputViewer extends React.Component<IRoadClosureOutputViewerPr
                             large={true}
                             text={"Back"}
                             onClick={this.handleClickCancel}/> */}
-                        { !process.env.REACT_APP_EDIT_ONLY &&
+                        { !process.env.REACT_APP_EDIT_ONLY && !this.props.readOnly && 
                         <Button
                             title={"You have to create a road closure before you can save & publish it"}
-                            disabled={this.props.isOutputItemEmpty || this.props.readOnly}
+                            disabled={this.props.isOutputItemEmpty}
                             large={true}
                             intent={"primary"}
                             text={this.props.isEditingExistingClosure ? "Save closure & Publish" : "Save closure & Publish"}
@@ -123,7 +123,7 @@ class RoadClosureOutputViewer extends React.Component<IRoadClosureOutputViewerPr
                             onClick={this.handleClickSave}/> 
                         }
                         {
-                            this.props.isEditingExistingClosure &&
+                            this.props.isEditingExistingClosure && !this.props.readOnly && 
                             <Button 
                                 onClick={this.handleOpenDialog}
                                 text={"View published closure links"}/>

--- a/src/components/road-closure-saved-data-item/index.tsx
+++ b/src/components/road-closure-saved-data-item/index.tsx
@@ -23,6 +23,7 @@ export interface IRoadClosureSavedDataItemProps {
     previewClosure: (e: any) => void,
     resetClosurePreview: () => void,
     highlightFeaturesGroup: (e: any) => void,
+    showMessage: (e: any) => void,
 };
 
 class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItemProps, any> {
@@ -58,6 +59,10 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
     }
 
     public handleClickCopyDirectURL = (e: any) => {
+        this.props.showMessage({
+            intent: "success",
+            text: `Copied link to open this closure in the editor!`,
+        });
         this.directUrlInput.select();
         document.execCommand('copy');
     }
@@ -71,6 +76,10 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
     } 
         
     public handleClickCopyGeoJSONURL = (e: any) => {
+        this.props.showMessage({
+            intent: "success",
+            text: `Copied link to GeoJSON file!`,
+        });
         this.geojsonUrlInput.select();
         document.execCommand('copy');
     }
@@ -80,6 +89,10 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
     }
         
     public handleClickCopyWazeURL = (e: any) => {
+        this.props.showMessage({
+            intent: "success",
+            text: `Copied link to Waze (CIFS) file!`,
+        });
         this.wazeUrlInput.select();
         document.execCommand('copy');
     }

--- a/src/components/road-closure-saved-data-item/index.tsx
+++ b/src/components/road-closure-saved-data-item/index.tsx
@@ -27,12 +27,14 @@ export interface IRoadClosureSavedDataItemProps {
 
 class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItemProps, any> {
     private directUrlInput: any;
+    private shareUrlInput: any;
     private geojsonUrlInput: any;
     private wazeUrlInput: any;
 
     public constructor(props: IRoadClosureSavedDataItemProps) {
         super(props);
         this.handleClickCopyDirectURL = this.handleClickCopyDirectURL.bind(this);
+        this.handleClickCopyShareURL = this.handleClickCopyShareURL.bind(this);
         this.handlePreviewClosure = this.handlePreviewClosure.bind(this);
         this.handleMouseout = this.handleMouseout.bind(this);
         this.handleMouseover = this.handleMouseover.bind(this);
@@ -46,6 +48,15 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
         };
     }
     
+    public handleClickCopyShareURL = (e: any) => {
+        this.props.showMessage({
+            intent: "success",
+            text: `Copied shareable, read-only link!`,
+        });
+        this.shareUrlInput.select();
+        document.execCommand('copy');
+    }
+
     public handleClickCopyDirectURL = (e: any) => {
         this.directUrlInput.select();
         document.execCommand('copy');
@@ -54,6 +65,10 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
     public handleSetDirectURLInputRef = (ref: HTMLInputElement | null) => {
         this.directUrlInput = ref;
     }
+
+    public handleSetShareURLInputRef = (ref: HTMLInputElement | null) => {
+        this.shareUrlInput = ref;
+    } 
         
     public handleClickCopyGeoJSONURL = (e: any) => {
         this.geojsonUrlInput.select();
@@ -110,6 +125,15 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
                 className={cardClassName}>
                 <div>
                     <div className={'SHST-Road-Closure-Saved-Data-Item-Buttons'}>
+                        {
+                            this.props.uploadUrls && this.props.uploadUrls.geojsonUploadUrl &&
+                            <Button
+                                rightIcon={"share"}
+                                text={"Copy view-only link"}
+                                small={true}
+                                onClick={this.handleClickCopyShareURL}
+                            />
+                        }
                         <Popover>
                             <Button
                                 rightIcon={"caret-down"}
@@ -201,7 +225,19 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
                     </div>
                 </div>
             </Card>
-
+            {
+                this.props.uploadUrls && this.props.uploadUrls.geojsonUploadUrl && 
+                <input
+                    ref={this.handleSetShareURLInputRef}
+                    value={window.location.origin+`/${this.props.orgName}/edit?readOnly=true&url=`+this.props.uploadUrls.geojsonUploadUrl}
+                    type={"text"}
+                    style={{
+                        // 'display': 'none',
+                        'left': '-1000px',
+                        'position': 'absolute',
+                        'top': '-1000px',
+                }} />
+            }
             {
                 this.props.uploadUrls && this.props.uploadUrls.geojsonUploadUrl && 
                 <input

--- a/src/components/road-closure-saved-data-item/index.tsx
+++ b/src/components/road-closure-saved-data-item/index.tsx
@@ -242,7 +242,7 @@ class RoadClosureSavedDataItem extends React.Component<IRoadClosureSavedDataItem
                 this.props.uploadUrls && this.props.uploadUrls.geojsonUploadUrl && 
                 <input
                     ref={this.handleSetShareURLInputRef}
-                    value={window.location.origin+`/${this.props.orgName}/edit?readOnly=true&url=`+this.props.uploadUrls.geojsonUploadUrl}
+                    value={window.location.origin+`/${this.props.orgName}/edit?url=${this.props.uploadUrls.geojsonUploadUrl}&readOnly=true`}
                     type={"text"}
                     style={{
                         // 'display': 'none',

--- a/src/components/road-closure-saved-data-viewer/index.tsx
+++ b/src/components/road-closure-saved-data-viewer/index.tsx
@@ -31,6 +31,7 @@ export interface IRoadClosureSavedDataViewerProps {
     setFilterLevel: (e: string, r?: DateRange) => void,
     setFilterRange: (e: DateRange) => void,
     setSortOrder: (e: string) => void,
+    showMessage: (e: any) => void,
 };
 
 export interface IRoadClosureSavedDataViewerState {
@@ -180,6 +181,7 @@ class RoadClosureSavedDataViewer extends React.Component<IRoadClosureSavedDataVi
                     {this.props.allRoadClosureItems && this.props.allRoadClosureItems.length > 0 && 
                         Object.keys(this.props.allRoadClosureItems).map((roadClosureId: any) => {
                             return <RoadClosureSavedDataItem
+                                        showMessage={this.props.showMessage}
                                         key={roadClosureId}
                                         highlightFeaturesGroup={this.props.highlightFeaturesGroup}
                                         previewClosure={this.props.previewClosure}

--- a/src/containers/road-closure-form/index.tsx
+++ b/src/containers/road-closure-form/index.tsx
@@ -17,6 +17,7 @@ const mapStateToProps = (state: RootState) => ({
     currentRoadClosureGroupsDirection: getContiguousFeatureGroupsDirections(state.roadClosure),
     currentRoadClosureGroupsGeometryIdPathMap: getGeometryIdPathMap(state.roadClosure),
     currentRoadClosureItem: currentRoadClosureItemSelector(state.roadClosure),
+    readOnly: state.context.readOnly,
     roadClosure: state.roadClosure,
     selectedIntervals: calendarIntervalSelector(state.roadClosure),
 });

--- a/src/containers/road-closure-header-menu/index.tsx
+++ b/src/containers/road-closure-header-menu/index.tsx
@@ -20,6 +20,7 @@ const mapStateToProps = (state: RootState, ownProps: IRoadClosureHeaderMenuConta
     isFetchingInput: state.roadClosure.isFetchingInput,
     isGeneratingUploadUrl: state.roadClosure.isGeneratingUploadUrl,
     orgName: state.context.orgName,
+    readOnly: state.context.readOnly
 });
 
 export default connect<{}, {}, IRoadClosureHeaderMenuProps>(

--- a/src/containers/road-closure-map/index.tsx
+++ b/src/containers/road-closure-map/index.tsx
@@ -23,7 +23,7 @@ const mapStateToProps = (state: RootState, ownProps: IRoadClosureMapContainerPro
     directionIconPoints: getDirectionIconPoints(state.roadClosure),
     highlightedFeatureGroup: state.roadClosure.highlightedFeatureGroup,
     intersectionPoints: getIntersectionPoints(state.roadClosure),
-    isDrawingEnabled: ownProps.isDrawingEnabled,
+    isDrawingEnabled: ownProps.isDrawingEnabled && !state.context.readOnly,
     roadBlockIconPoints: getRoadBlockIconPoints(state.roadClosure),
     roadClosure: state.roadClosure,
 });

--- a/src/containers/road-closure-output-viewer/index.tsx
+++ b/src/containers/road-closure-output-viewer/index.tsx
@@ -20,6 +20,7 @@ const mapStateToProps = (state: RootState) => ({
     outputFormat: state.roadClosure.output.outputFormat,
     outputItem: currentRoadClosureItemOutput(state.roadClosure),
     outputItemFormattedJSONString: getFormattedJSONStringFromOutputItem(state.roadClosure),
+    readOnly: state.context.readOnly,
     uploadUrls: state.roadClosure.uploadUrls,
 });
 

--- a/src/containers/road-closure-saved-data-viewer/index.tsx
+++ b/src/containers/road-closure-saved-data-viewer/index.tsx
@@ -5,6 +5,7 @@ import {
     sortRoadClosureSavedItemsByLastModified
 } from 'src/selectors/road-closure-saved-items';
 import { RootState } from 'src/store/configureStore';
+import { CONTEXT_ACTIONS } from 'src/store/context';
 import { 
     ROAD_CLOSURE_ACTIONS
 } from '../../store/road-closure';
@@ -35,5 +36,6 @@ export default connect<{}, {}, IRoadClosureSavedDataViewerProps>(
         setFilterLevel: ROAD_CLOSURE_EXPLORER_ACTIONS.SET_ALL_ROAD_CLOSURES_FILTER_LEVEL,
         setFilterRange: ROAD_CLOSURE_EXPLORER_ACTIONS.SET_ALL_ROAD_CLOSURES_FILTER_RANGE,
         setSortOrder: ROAD_CLOSURE_EXPLORER_ACTIONS.SET_ALL_ROAD_CLOSURES_SORT_ORDER,
+        showMessage: CONTEXT_ACTIONS.SHOW_MESSAGE
     },
 )(RoadClosureSavedDataViewer) as React.ComponentClass<{}>;

--- a/src/screens/road-closure-explorer/index.tsx
+++ b/src/screens/road-closure-explorer/index.tsx
@@ -5,12 +5,17 @@ import SharedStreetsHeader from '../../components/sharedstreets-header';
 import { RootState } from '../../store/configureStore';
 import './road-closure-explorer.css';
 
-import { FocusStyleManager } from "@blueprintjs/core";
+import {
+  FocusStyleManager,
+  Intent,
+  Position,
+  Toaster,
+} from "@blueprintjs/core";
 import RoadClosureHeaderMenu from 'src/containers/road-closure-header-menu';
 import RoadClosureMap from 'src/containers/road-closure-map';
 import RoadClosureSavedDataViewer from 'src/containers/road-closure-saved-data-viewer';
 import {
-  CONTEXT_ACTIONS
+  CONTEXT_ACTIONS, IContextMessage
 } from '../../store/context';
 import {
   loadAllRoadClosures,
@@ -22,15 +27,34 @@ export interface IRoadClosureExplorerProps {
   isShowingRoadClosureOutputViewer: boolean,
   explore: boolean,
   match: any,
+  message: IContextMessage,
+  hideMessage: (d: boolean) => void,
   setOrgName: (payload: string) => void
   loadAllRoadClosures: () => void
 };
+const ExploreToaster = Toaster.create({
+  className: "SHST-Top-Toaster",
+  position: Position.TOP,
+});
 
 class RoadClosureExplorer extends React.Component<IRoadClosureExplorerProps, any> {
   public componentDidMount() {
     if (this.props.match.params.org) {
       Promise.resolve(this.props.setOrgName(this.props.match.params.org))
       .then(() => this.props.loadAllRoadClosures())
+    }
+  }
+
+  public componentDidUpdate(prevProps: IRoadClosureExplorerProps) {
+    if (prevProps.message.text !== this.props.message.text
+      && prevProps.message.intent !== this.props.message.intent
+      && this.props.message.text !== ""
+      ) {
+        ExploreToaster.show({
+          intent: this.props.message.intent as Intent,
+          message: this.props.message.text,
+          onDismiss: this.props.hideMessage
+        });
     }
   }
 
@@ -52,8 +76,10 @@ class RoadClosureExplorer extends React.Component<IRoadClosureExplorerProps, any
 export default connect<{}, {}, IRoadClosureExplorerProps>(
   (state: RootState) => ({
     isShowingRoadClosureOutputViewer: state.roadClosure.isShowingRoadClosureOutputViewer,
+    message: state.context.message,
   }), 
   {
+    hideMessage: CONTEXT_ACTIONS.HIDE_MESSAGE,
     loadAllRoadClosures,
     setOrgName: CONTEXT_ACTIONS.SET_ORG_NAME,
   }

--- a/src/screens/road-closure-explorer/road-closure-explorer.css
+++ b/src/screens/road-closure-explorer/road-closure-explorer.css
@@ -9,6 +9,10 @@
     width: 100%;
     height: calc(100% - 44px);
 }
+
+.SHST-Top-Toaster {
+    margin-top: 44px;
+}
 /* 
 @media screen and (max-width: 1024px) {
     .SHST-Container {

--- a/src/store/context/index.ts
+++ b/src/store/context/index.ts
@@ -23,6 +23,7 @@ export interface IContextMessage {
 export const CONTEXT_ACTIONS = {
     HIDE_MESSAGE: createStandardAction('CONTEXT/HIDE_MESSAGE')<boolean>(),
     SET_ORG_NAME: createStandardAction('CONTEXT/SET_ORG_NAME')<string>(),
+    SET_READ_ONLY: createStandardAction('CONTEXT/SET_READ_ONLY')<IContextMessage>(),
     SHOW_MESSAGE: createStandardAction('CONTEXT/SHOW_MESSAGE')<IContextMessage>(),
 };
 
@@ -31,6 +32,7 @@ export const CONTEXT_ACTIONS = {
 export interface IContextState {
     message: IContextMessage,
     orgName: string,
+    readOnly: boolean,
 };
 
 const defaultState: IContextState = {
@@ -39,6 +41,7 @@ const defaultState: IContextState = {
         text: '',
     },
     orgName: '',
+    readOnly: false,
 };
 
 export const contextReducer = (state: IContextState = defaultState, action: ContextAction) => {
@@ -64,6 +67,11 @@ export const contextReducer = (state: IContextState = defaultState, action: Cont
                 orgName: action.payload
             }
 
+        case 'CONTEXT/SET_READ_ONLY':
+            return {
+                ...state,
+                readOnly: true,
+            }
         default:
             return state;
     }


### PR DESCRIPTION
#### Issue
In the absence of authentication, we need a quick way to view (read, not write) data. 

#### Change 
As a quick fix, adds a URL param that renders the editor without the ability to edit:
![image](https://user-images.githubusercontent.com/444765/64736865-a1cb3c00-d4b9-11e9-9f9e-4b048426c9ed.png)

Also adds a button to copy a link to a read-only closure:
![image](https://user-images.githubusercontent.com/444765/64736594-fe7a2700-d4b8-11e9-87b8-f7a89800e128.png)
